### PR TITLE
Fix build errors introduced with Debian Stretch and PHP 7.2

### DIFF
--- a/images/build-apache-php7-varnish/Dockerfile
+++ b/images/build-apache-php7-varnish/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7-apache
+FROM php:7.1-apache
 
 ADD php/_010_php.ini /usr/local/etc/php/conf.d/
 

--- a/images/build-apache-php7-xdebug/Dockerfile
+++ b/images/build-apache-php7-xdebug/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7-apache
+FROM php:7.1-apache
 
 ADD php/_010_php.ini /usr/local/etc/php/conf.d/
 

--- a/images/build-assetgenerator/Dockerfile
+++ b/images/build-assetgenerator/Dockerfile
@@ -4,8 +4,8 @@ RUN apt-get update && apt-get install -y \
         libfreetype6-dev \
         libjpeg62-turbo-dev \
         libmcrypt-dev \
-        libpng12-dev \
-    && docker-php-ext-install -j$(nproc) iconv mcrypt \
+        libpng-dev \
+    && docker-php-ext-install -j$(nproc) iconv \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install -j$(nproc) gd \
     && rm -rf /var/lib/apt/lists/* \

--- a/images/build-php7-cli-xdebug/Dockerfile
+++ b/images/build-php7-cli-xdebug/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7-cli
+FROM php:7.1-cli
 
 ADD php/_010_php.ini /usr/local/etc/php/conf.d/
 

--- a/images/build-php7-cli/Dockerfile
+++ b/images/build-php7-cli/Dockerfile
@@ -2,13 +2,11 @@ FROM php:7-cli
 
 ADD php/_010_php.ini /usr/local/etc/php/conf.d/
 
-RUN apt-get update && apt-get install --no-install-recommends -y \
-        openjdk-7-jre-headless \
+RUN mkdir -p /usr/share/man/man1 && apt-get update && apt-get install --no-install-recommends -y \
         ant \
         libfreetype6-dev \
         libjpeg62-turbo-dev \
-        libmcrypt-dev \
-        libpng12-dev \
+        libpng-dev \
         zip \
         zlib1g-dev \
         unzip \
@@ -22,7 +20,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
         libxml2 \
         libxml2-dev \
         libssl-dev \
-    && docker-php-ext-install -j$(nproc) iconv mcrypt \
+    && docker-php-ext-install -j$(nproc) iconv \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install -j$(nproc) gd \
     && docker-php-ext-install mbstring \
@@ -31,6 +29,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     && docker-php-ext-install soap \
     && docker-php-ext-install curl \
     && docker-php-ext-install pdo pdo_mysql \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && echo "date.timezone = 'Europe/Berlin'" >> /usr/local/etc/php/php.ini \
     && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \


### PR DESCRIPTION
 - Locked PHP-Version of images built with xdebug support to 7.1, as there's no official package of xdebug for PHP > 7.1 [at the moment](https://xdebug.org/download.php)
 - Removed references to `libpng12` package  from images built upon Debian Stretch, as that version [isn't available](https://packages.debian.org/search?searchon=names&keywords=libpng)
 - Removed `mcrypt` module from images built with PHP 7.2, as support was [removed](http://php.net/manual/en/intro.mcrypt.php)
 - Creating directory `/usr/share/man/man1` before `ant` installation as that resolves `error creating symbolic link '/usr/share/man/man1/rmid.1.gz.dpkg-tmp` when installing the `ca-certificates-java` dependency of `openjdk-8-jre-headless`