### PR TITLE
Disabled opcache on nginx, adjustments on xdebug

### DIFF
--- a/images/build-nginx-php7/Dockerfile
+++ b/images/build-nginx-php7/Dockerfile
@@ -1,9 +1,12 @@
 FROM jeboehm/php-nginx-base
 
 COPY config/nginx.conf /etc/nginx
+COPY config/limits.ini /usr/local/etc/php/conf.d/limits.ini
+COPY config/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
 
 WORKDIR /var/www/html
 
 RUN echo http://dl-2.alpinelinux.org/alpine/edge/community/ >> /etc/apk/repositories \
     && apk --no-cache add shadow && usermod -u 1000 www-data \
-    && chown -R www-data /var/www
+    && chown -R www-data /var/www \
+    && rm /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini

--- a/images/build-nginx-php7/config/limits.ini
+++ b/images/build-nginx-php7/config/limits.ini
@@ -1,0 +1,4 @@
+upload_max_filesize = 20M
+post_max_size = 20M
+max_execution_time = 30
+memory_limit = 512G

--- a/images/build-nginx-php7/config/xdebug.ini
+++ b/images/build-nginx-php7/config/xdebug.ini
@@ -1,0 +1,9 @@
+xdebug.remote_enable=1
+xdebug.remote_autostart=0
+xdebug.remote_connect_back=1
+xdebug.remote_port=9000
+xdebug.remote_log=/tmp/php7-xdebug.log
+xdebug.idekey=PHPSTORM
+xdebug.var_display_max_depth = 5 
+xdebug.var_display_max_children = 256
+xdebug.var_display_max_data = 1024 

--- a/nginx/conf.d/.gitignore
+++ b/nginx/conf.d/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
Would be cool if you can update the docker hub image after pull :+1: 